### PR TITLE
feat: created authentication guarded route component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,17 +1,16 @@
-import { useContext } from 'react';
 import { Switch, Route } from 'react-router-dom';
 import './App.css';
 
-import { AuthContext } from './auth';
+import { AuthRoute } from './common';
 import LoginPage from './Login/LoginPage';
+
+const Home = () => (<h1>Welcome to Pinder</h1>);
 
 function App() {
 
-    const auth = useContext(AuthContext);
-
     return (
         <Switch>
-            <Route path='/' exact={true} render={() => (<h1>Welcome to Pinder</h1>)} />
+            <AuthRoute path='/' exact={true} component={Home} />
             <Route path='/login' component={LoginPage} /> 
         </Switch>
     );

--- a/frontend/src/common/AuthRoute.js
+++ b/frontend/src/common/AuthRoute.js
@@ -1,0 +1,17 @@
+import { useContext } from 'react';
+import { Route, Redirect } from 'react-router-dom';
+import { AuthContext } from '../auth';
+
+const AuthRoute = ({ component: Component, ...rest }) => {
+    const auth = useContext(AuthContext);
+
+    return (
+        <Route {...rest} render={(props) => (
+            auth.getCurrentUser()
+                ? <Component {...props} />
+                : <Redirect to='/login' />
+        )} />
+    )
+};
+
+export default AuthRoute;

--- a/frontend/src/common/index.js
+++ b/frontend/src/common/index.js
@@ -1,0 +1,3 @@
+import AuthRoute from './AuthRoute';
+
+export { AuthRoute };


### PR DESCRIPTION
Created an auth guard router in src/common/AuthRoute.js which should be used for routes that require a user to be authenticated (should be all routes except for /login and /register).

The component is used like the normal `Route` component that is part of react-router-dom. The only difference is that Route can accept either a `render` prop or `component` prop, but AuthRoute requires a `component` prop. This shouldn't be a problem however, since we don't really have a use case for the `render` prop.